### PR TITLE
Cleanup + none-OVK support

### DIFF
--- a/ledger-zcash/Cargo.toml
+++ b/ledger-zcash/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ledger-zcash"
 description = "Library to integrate with the Ledger Zcash app"
-version = "0.0.4"
+version = "0.0.5"
 license = "Apache-2.0"
 authors = ["Zondax GmbH <info@zondax.ch>"]
 homepage = "https://github.com/Zondax/ledger-zcash-rs"
@@ -34,7 +34,7 @@ secp256k1 = { version = "0.19.0", default-features = false }
 group = "0.8.0"
 sha2 = "0.9.2"
 
-zcash-hsmbuilder = { path = "../zcash-hsmbuilder", version = "0.0.4" }
+zcash-hsmbuilder = { path = "../zcash-hsmbuilder", version = "0.0.5" }
 
 [dependencies.zcash_primitives]
 version = "0.4.0"

--- a/ledger-zcash/Cargo.toml
+++ b/ledger-zcash/Cargo.toml
@@ -19,7 +19,7 @@ circle-ci = { repository = "zondax/ledger-zcash-rs" }
 name = "ledger_zcash"
 
 [dependencies]
-byteorder = "1.3.4"
+byteorder = "1.4.2"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.22"

--- a/ledger-zcash/Cargo.toml
+++ b/ledger-zcash/Cargo.toml
@@ -19,7 +19,7 @@ circle-ci = { repository = "zondax/ledger-zcash-rs" }
 name = "ledger_zcash"
 
 [dependencies]
-byteorder = "1.4.2"
+byteorder = "1.3.4"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.22"

--- a/ledger-zcash/Cargo.toml
+++ b/ledger-zcash/Cargo.toml
@@ -19,15 +19,15 @@ circle-ci = { repository = "zondax/ledger-zcash-rs" }
 name = "ledger_zcash"
 
 [dependencies]
-byteorder = "1.3.4"
+byteorder = "1.4.2"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0.22"
-log = "0.4.11"
+thiserror = "1.0.23"
+log = "0.4.13"
 zx-bip44 = "0.1.0"
-ledger-zondax-generic = "0.7.0"
-ledger-transport = "0.7.0"
-ledger-transport-hid = "0.7.0"
+ledger-zondax-generic = "0.8.0"
+ledger-transport = "0.8.0"
+ledger-transport-hid = "0.8.0"
 hex = "0.4.2"
 jubjub = { version = "0.5.1", default-features = false }
 secp256k1 = { version = "0.19.0", default-features = false }
@@ -41,9 +41,9 @@ version = "0.4.0"
 features = ["transparent-inputs"]
 
 [dev-dependencies]
-futures = "0.3.8"
+futures = "0.3.11"
 matches = "0.1.8"
 serial_test = "0.5.1"
 env_logger = "0.8.2"
 tokio = { version = "0.2", features = ["full"] }
-tokio-test = "0.3.0"
+tokio-test = "0.4.0"

--- a/ledger-zcash/src/app.rs
+++ b/ledger-zcash/src/app.rs
@@ -44,8 +44,9 @@ use zx_bip44::BIP44Path;
 use byteorder::{LittleEndian, WriteBytesExt};
 use zcash_hsmbuilder::txbuilder::TransactionMetadata;
 use zcash_hsmbuilder::{
-    InitData, OutputBuilderInfo, ShieldedOutputData, ShieldedSpendData, SpendBuilderInfo, TinData,
-    ToutData, TransactionSignatures, TransparentInputBuilderInfo, TransparentOutputBuilderInfo,
+    HashSeed, InitData, OutputBuilderInfo, ShieldedOutputData, ShieldedSpendData, SpendBuilderInfo,
+    TinData, ToutData, TransactionSignatures, TransparentInputBuilderInfo,
+    TransparentOutputBuilderInfo,
 };
 
 use sha2::{Digest, Sha256};
@@ -262,6 +263,10 @@ impl DataShieldedOutput {
 
     ///Take the fields plus additional inputs to send to builder
     pub fn to_builder_data(&self, outputinfo: (jubjub::Fr, Rseed)) -> OutputBuilderInfo {
+        let seed = match self.ovk {
+            None => Some(HashSeed([0u8; 32])),
+            Some(_) => None,
+        };
         OutputBuilderInfo {
             rcv: outputinfo.0,
             rseed: outputinfo.1,
@@ -269,6 +274,7 @@ impl DataShieldedOutput {
             address: self.address.clone(),
             value: self.value,
             memo: self.memo.clone(),
+            hash_seed: seed,
         }
     }
 }

--- a/ledger-zcash/src/lib.rs
+++ b/ledger-zcash/src/lib.rs
@@ -15,15 +15,7 @@
 ********************************************************************************/
 //! Support library for Zcash Ledger Nano S/X apps
 
-#![cfg_attr(
-    not(test),
-    deny(
-        clippy::option_unwrap_used,
-        clippy::option_expect_used,
-        clippy::result_unwrap_used,
-        clippy::result_expect_used,
-    )
-)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used,))]
 #![deny(warnings, trivial_casts, trivial_numeric_casts)]
 #![deny(unused_import_braces, unused_qualifications)]
 #![deny(missing_docs)]

--- a/ledger-zcash/tests/integration_test.rs
+++ b/ledger-zcash/tests/integration_test.rs
@@ -584,7 +584,7 @@ mod integration_tests {
             memo: None,
         };
 
-        let fee = 10000;
+        let fee = 1000;
 
         let txfee = Amount::from_u64(fee).unwrap();
         let change_amount = spend1.value + spend2.value - output1.value - txfee;

--- a/zcash-hsmbuilder/Cargo.toml
+++ b/zcash-hsmbuilder/Cargo.toml
@@ -23,7 +23,7 @@ jubjub = { version = "0.5.1", default-features = false }
 bellman = { version = "0.8", default-features = false, features = ["groth16"] }
 blake2b_simd = "0.5"
 bls12_381 = { version = "0.3.1" }
-byteorder = "1"
+byteorder = "1.4.2"
 directories = { version = "3", optional = true }
 ff = { version = "0.8.0" }
 lazy_static = "1"

--- a/zcash-hsmbuilder/Cargo.toml
+++ b/zcash-hsmbuilder/Cargo.toml
@@ -23,7 +23,7 @@ jubjub = { version = "0.5.1", default-features = false }
 bellman = { version = "0.8", default-features = false, features = ["groth16"] }
 blake2b_simd = "0.5"
 bls12_381 = { version = "0.3.1" }
-byteorder = "1.4.2"
+byteorder = "1.3.4"
 directories = { version = "3", optional = true }
 ff = { version = "0.8.0" }
 lazy_static = "1"

--- a/zcash-hsmbuilder/Cargo.toml
+++ b/zcash-hsmbuilder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash-hsmbuilder"
 description = "Library to build transactions for HSM apps"
-version = "0.0.4"
+version = "0.0.5"
 license = "Apache-2.0"
 authors = ["Zondax GmbH <info@zondax.ch>"]
 homepage = "https://github.com/Zondax/ledger-zcash-rs"

--- a/zcash-hsmbuilder/src/errors.rs
+++ b/zcash-hsmbuilder/src/errors.rs
@@ -18,6 +18,7 @@ pub enum Error {
     MinShieldedOuputs,
     BuilderNoKeys,
     ReadWriteError,
+    InvalidOVKHashSeed,
 }
 
 impl fmt::Display for Error {
@@ -40,6 +41,7 @@ impl fmt::Display for Error {
             Error::MinShieldedOuputs => write!(f, "Not enough shielded outputs for transaction"),
             Error::BuilderNoKeys => write!(f, "Builder does not have any keys set"),
             Error::ReadWriteError => write!(f, "Error writing/reading bytes to/from vector"),
+            Error::InvalidOVKHashSeed => write!(f, "Error: either OVK or hashseed should be some"),
         }
     }
 }

--- a/zcash-hsmbuilder/src/lib.rs
+++ b/zcash-hsmbuilder/src/lib.rs
@@ -123,8 +123,10 @@ impl InitData {
             data.extend_from_slice(&info.value.to_i64_le_bytes());
             data.push(info.memo_type);
             if info.ovk.is_some() {
+                data.push(0x01);
                 data.extend_from_slice(&info.ovk.unwrap().0);
             } else {
+                data.push(0x00);
                 data.extend_from_slice(&[0u8; 32]);
             }
         }

--- a/zcash-hsmbuilder/src/lib.rs
+++ b/zcash-hsmbuilder/src/lib.rs
@@ -301,6 +301,9 @@ impl ZcashBuilder {
     }
 
     pub fn add_sapling_output(&mut self, info: OutputBuilderInfo) -> Result<(), Error> {
+        if info.ovk.is_none() && info.hash_seed.is_none() {
+            return Err(Error::InvalidOVKHashSeed);
+        }
         let r = self.builder.add_sapling_output(
             info.ovk,
             info.address,

--- a/zcash-hsmbuilder/src/lib.rs
+++ b/zcash-hsmbuilder/src/lib.rs
@@ -163,9 +163,6 @@ impl HsmTxData {
 }
 
 pub struct ZcashBuilder {
-    secret_key: Option<[u8; 32]>,
-    public_key: Option<[u8; 32]>,
-    session_key: Option<[u8; 32]>,
     num_transparent_inputs: usize,
     num_transparent_outputs: usize,
     num_spends: usize,
@@ -213,6 +210,10 @@ pub struct SpendBuilderInfo {
     pub rseed: Rseed,
 }
 
+/// An outgoing viewing key
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HashSeed(pub [u8; 32]);
+
 #[derive(Debug, Deserialize)]
 pub struct OutputBuilderInfo {
     #[serde(deserialize_with = "fr_deserialize")]
@@ -227,6 +228,8 @@ pub struct OutputBuilderInfo {
     pub value: Amount,
     #[serde(deserialize_with = "memo_deserialize")]
     pub memo: Option<Memo>,
+    #[serde(deserialize_with = "hashseed_deserialize")]
+    pub hash_seed: Option<HashSeed>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -240,9 +243,6 @@ pub struct TransactionSignatures {
 impl ZcashBuilder {
     pub fn new(fee: u64) -> ZcashBuilder {
         ZcashBuilder {
-            secret_key: None,
-            public_key: None,
-            session_key: None,
             num_transparent_inputs: 0,
             num_transparent_outputs: 0,
             num_spends: 0,
@@ -308,6 +308,7 @@ impl ZcashBuilder {
             info.memo,
             info.rcv,
             info.rseed,
+            info.hash_seed,
         );
         if r.is_ok() {
             self.num_outputs += 1;

--- a/zcash-hsmbuilder/src/lib.rs
+++ b/zcash-hsmbuilder/src/lib.rs
@@ -3,7 +3,8 @@
     unused_imports,
     unused_mut,
     unused_variables,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::result_unit_err
 )]
 
 extern crate hex;

--- a/zcash-hsmbuilder/src/neon_bridge.rs
+++ b/zcash-hsmbuilder/src/neon_bridge.rs
@@ -1,5 +1,6 @@
 use std::str::*;
 
+use crate::HashSeed;
 use group::GroupEncoding;
 use jubjub::{Fr, SubgroupPoint};
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
@@ -210,5 +211,19 @@ where
             v.push(s.unwrap());
         }
         Ok(v)
+    }
+}
+
+pub fn hashseed_deserialize<'de, D>(deserializer: D) -> Result<Option<HashSeed>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let str: Option<String> = Option::deserialize(deserializer)?;
+    if let Some(s) = str {
+        let mut bytes = [0u8; 32];
+        hex::decode_to_slice(&s, &mut bytes).map_err(D::Error::custom)?;
+        Ok(Some(HashSeed(bytes)))
+    } else {
+        Ok(None)
     }
 }


### PR DESCRIPTION
This PR:
- Cleans up some rust functions (closes https://github.com/Zondax/ledger-zcash-rs/issues/4).
- Supports non-OVK's by hashing random bytes retrieved from the hsm, instead of generating random bytes itself.