### PR TITLE
Add support for INS_GET_NF

### DIFF
--- a/ledger-zcash/tests/integration_test.rs
+++ b/ledger-zcash/tests/integration_test.rs
@@ -60,7 +60,7 @@ async fn version() {
     println!("patch {}", resp.patch);
     println!("locked {}", resp.locked);
 
-    assert_eq!(resp.major, 2);
+    assert_eq!(resp.major, 3);
 }
 
 #[tokio::test]

--- a/ledger-zcash/tests/integration_test.rs
+++ b/ledger-zcash/tests/integration_test.rs
@@ -271,7 +271,7 @@ async fn do_full_transaction_shieldedonly() {
         },
         witness: IncrementalWitness::read(
             &hex::decode(
-                "01305aef35a6fa9dd43af22d2557f99268fbab70a53e963fa67fc762391510406000000000",
+                "0102cda01d86b1a443f4012e639556616fa4638233b93a61d12bd30c38ca678d69000101fef93fadf0bfbd769ec217949b45ca5fef3f1b6ae2aebdfbfac8a5f29cd9e24901d0282378d8c5c23edd6be1a5ab023ab608c3ba21411dd7824dd1f52ad074382a00",
             )
             .unwrap()[..],
         )
@@ -380,7 +380,7 @@ async fn do_full_transaction_combinedshieldtransparent() {
         diversifier: d,
         witness: IncrementalWitness::read(
             &hex::decode(
-                "01305aef35a6fa9dd43af22d2557f99268fbab70a53e963fa67fc762391510406000000000",
+                "0102cda01d86b1a443f4012e639556616fa4638233b93a61d12bd30c38ca678d69000101fef93fadf0bfbd769ec217949b45ca5fef3f1b6ae2aebdfbfac8a5f29cd9e24901d0282378d8c5c23edd6be1a5ab023ab608c3ba21411dd7824dd1f52ad074382a00",
             )
             .unwrap()[..],
         )
@@ -531,7 +531,7 @@ async fn do_full_tx_in_pieces() {
         },
         witness: IncrementalWitness::read(
             &hex::decode(
-                "01305aef35a6fa9dd43af22d2557f99268fbab70a53e963fa67fc762391510406000000000",
+                "0102cda01d86b1a443f4012e639556616fa4638233b93a61d12bd30c38ca678d69000101fef93fadf0bfbd769ec217949b45ca5fef3f1b6ae2aebdfbfac8a5f29cd9e24901d0282378d8c5c23edd6be1a5ab023ab608c3ba21411dd7824dd1f52ad074382a00",
             )
             .unwrap()[..],
         )

--- a/zcash-hsmbuilder/src/prover.rs
+++ b/zcash-hsmbuilder/src/prover.rs
@@ -151,8 +151,7 @@ impl SaplingProvingContext {
 
         // Try to verify the proof:
         // Construct public input for circuit
-        //Fixme: do this when the anchor is set correct
-        /*
+
         let mut public_input = [bls12_381::Scalar::zero(); 7];
         {
             let affine = rk.0.to_affine();
@@ -181,7 +180,7 @@ impl SaplingProvingContext {
 
         // Verify the proof
         verify_proof(verifying_key, &proof, &public_input[..]).map_err(|_| ())?;
-        */
+
         // Compute value commitment
         let value_commitment: jubjub::ExtendedPoint = value_commitment.commitment().into();
 

--- a/zcash-hsmbuilder/src/prover.rs
+++ b/zcash-hsmbuilder/src/prover.rs
@@ -170,7 +170,7 @@ impl SaplingProvingContext {
 
         // Add the nullifier through multiscalar packing
         {
-            let nullifier = multipack::bytes_to_bits_le(&nullifier);
+            let nullifier = multipack::bytes_to_bits_le(&nullifier.0);
             let nullifier = multipack::compute_multipacking(&nullifier);
 
             assert_eq!(nullifier.len(), 2);

--- a/zcash-hsmbuilder/src/txbuilder.rs
+++ b/zcash-hsmbuilder/src/txbuilder.rs
@@ -137,11 +137,6 @@ impl<P: consensus::Parameters, R: RngCore + CryptoRng> Builder<P, R> {
         rcv: jubjub::Fr,              //get from ledger
     ) -> Result<(), Error> {
         // Consistency check: all anchors must equal the first one
-        //Fixme: add this later when we get info from chain
-        // so that the tests don't fail
-        // see: https://github.com/Zondax/ledger-zcash-rs/issues/5
-        self.anchor = Some(bls12_381::Scalar::one());
-        /*
         let cmu = Node::new(note.cmu().into());
         if let Some(anchor) = self.anchor {
             let path_root: bls12_381::Scalar = merkle_path.root(cmu).into();
@@ -151,7 +146,6 @@ impl<P: consensus::Parameters, R: RngCore + CryptoRng> Builder<P, R> {
         } else {
             self.anchor = Some(merkle_path.root(cmu).into())
         }
-         */
 
         self.mtx.value_balance += Amount::from_u64(note.value).map_err(|_| Error::InvalidAmount)?;
 


### PR DESCRIPTION
Work by @IdaTucker.

This PR adds support for the new instruction to retrieve the note nullifier, as well as enabling the anchor check by updating the test data so that the check can work properly.

Closes #5 

<!-- ClickUpRef: 2hxzfxw -->
:link: [zboto Link](https://app.clickup.com/t/2hxzfxw)