### PR TITLE
Update crates to 0.20 if possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 /target
 
 \.idea/
+
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = ["crate_test", "ledger-zcash", "ledger-zcash-builder"]
 
+
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"

--- a/crate_test/Cargo.toml
+++ b/crate_test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-zcash_primitives = { version = "0.7", features = ["transparent-inputs"] }
+zcash_primitives = { version = "0.8", features = ["transparent-inputs"] }
 
 ledger-zcash-builder = { path = "../ledger-zcash-builder", version = "=0.11.2" }
 ledger-zcash = { path = "../ledger-zcash", version = "=0.11.2" }

--- a/ledger-zcash-builder/Cargo.toml
+++ b/ledger-zcash-builder/Cargo.toml
@@ -38,7 +38,7 @@ bls12_381 = { version = "0.7" }
 chacha20poly1305 = "0.9"
 ff = "0.12"
 group = "0.12"
-jubjub = { version = "0.9", default-features = false }
+jubjub = { version = "0.10", default-features = false }
 pairing = { version = "0.22" }
 rand = { version = "0.8.5", default-features = false }
 rand_core = "0.6.4"

--- a/ledger-zcash-builder/Cargo.toml
+++ b/ledger-zcash-builder/Cargo.toml
@@ -50,5 +50,5 @@ wagyu-zcash-parameters = { version = "0.2", optional = true }
 ledger-zcash-legacy-helpers = { path = "../ledger-zcash-legacy-helpers" }
 zcash_primitives = { version = "0.8", features = ["transparent-inputs"] }
 zcash_proofs = { version = "0.8", features = ["multicore"], optional = true }
-zcash_note_encryption = { version = "0.1", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
 thiserror = "1.0"

--- a/ledger-zcash-builder/Cargo.toml
+++ b/ledger-zcash-builder/Cargo.toml
@@ -48,7 +48,7 @@ secp256k1 = { version = "0.29" }
 #zcash
 wagyu-zcash-parameters = { version = "0.2", optional = true }
 
-zcash_primitives = { version = "0.7", features = ["transparent-inputs"] }
-zcash_proofs = { version = "0.7", features = ["multicore"], optional = true }
+zcash_primitives = { version = "0.8", features = ["transparent-inputs"] }
+zcash_proofs = { version = "0.8", features = ["multicore"], optional = true }
 zcash_note_encryption = { version = "0.1", features = ["pre-zip-212"] }
 thiserror = "1.0"

--- a/ledger-zcash-builder/Cargo.toml
+++ b/ledger-zcash-builder/Cargo.toml
@@ -48,7 +48,10 @@ secp256k1 = { version = "0.29" }
 #zcash
 wagyu-zcash-parameters = { version = "0.2", optional = true }
 ledger-zcash-legacy-helpers = { path = "../ledger-zcash-legacy-helpers" }
-zcash_primitives = { version = "0.8", features = ["transparent-inputs"] }
-zcash_proofs = { version = "0.8", features = ["multicore"], optional = true }
+zcash_primitives = { version = "0.20", features = ["transparent-inputs"] }
+zcash_proofs = { version = "0.20", features = ["multicore"], optional = true }
 zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
 thiserror = "1.0"
+sapling-crypto = "0.3"
+incrementalmerkletree = "0.7"
+redjubjub = "0.7"

--- a/ledger-zcash-builder/Cargo.toml
+++ b/ledger-zcash-builder/Cargo.toml
@@ -47,7 +47,7 @@ secp256k1 = { version = "0.29" }
 
 #zcash
 wagyu-zcash-parameters = { version = "0.2", optional = true }
-
+ledger-zcash-legacy-helpers = { path = "../ledger-zcash-legacy-helpers" }
 zcash_primitives = { version = "0.8", features = ["transparent-inputs"] }
 zcash_proofs = { version = "0.8", features = ["multicore"], optional = true }
 zcash_note_encryption = { version = "0.1", features = ["pre-zip-212"] }

--- a/ledger-zcash-builder/src/data.rs
+++ b/ledger-zcash-builder/src/data.rs
@@ -24,12 +24,18 @@ pub mod sighashdata_v4;
 pub mod sighashdata_v5;
 use serde::{Deserialize, Serialize};
 use sighashdata::TransactionDataSighash;
-use zcash_primitives::{
+use sapling_crypto::{
     keys::OutgoingViewingKey,
+    MerklePath,
+    Node,
+    PaymentAddress,
+    ProofGenerationKey, 
+    Rseed,
+};
+use redjubjub::{Signature, SpendAuth};
+use zcash_primitives::{
     legacy::Script,
     memo::MemoBytes as Memo,
-    merkle_tree::MerklePath,
-    sapling::{redjubjub::Signature, Node, PaymentAddress, ProofGenerationKey, Rseed},
     transaction::components::{Amount, OutPoint},
 };
 
@@ -194,7 +200,7 @@ pub struct SpendBuilderInfo {
     #[serde(deserialize_with = "amount_deserialize")]
     pub value: Amount, // Expected: u64 value representing an Amount
     #[serde(deserialize_with = "merkle_path_deserialize")]
-    pub witness: MerklePath<Node>, // Expected: Hex-encoded string representing a MerklePath<Node>
+    pub witness: MerklePath, // Expected: Hex-encoded string representing a MerklePath<Node>
     #[serde(deserialize_with = "rseed_deserialize")]
     pub rseed: Rseed, // Expected: Hex-encoded string representing a Rseed
 }
@@ -227,5 +233,5 @@ pub struct TransactionSignatures {
     #[serde(deserialize_with = "t_sig_deserialize")]
     pub transparent_sigs: Vec<secp256k1::ecdsa::Signature>, // Expected: List of hex-encoded strings representing secp256k1::ecdsa::Signature
     #[serde(deserialize_with = "s_sig_deserialize")]
-    pub sapling_sigs: Vec<Signature>, // Expected: List of hex-encoded strings representing Signature
+    pub sapling_sigs: Vec<Signature<SpendAuth>>, // Expected: List of hex-encoded strings representing Signature
 }

--- a/ledger-zcash-builder/src/data/neon_bridge.rs
+++ b/ledger-zcash-builder/src/data/neon_bridge.rs
@@ -4,14 +4,17 @@ use group::GroupEncoding;
 use jubjub::{Fr, SubgroupPoint};
 use serde::{de::Error, Deserialize, Deserializer, Serializer};
 use zcash_primitives::{
-    keys::OutgoingViewingKey,
     legacy::Script,
     memo::MemoBytes as Memo,
-    merkle_tree::{IncrementalWitness, MerklePath},
-    sapling::{redjubjub::Signature, Node, PaymentAddress, ProofGenerationKey, Rseed},
     transaction::components::{Amount, OutPoint},
 };
-
+use sapling_crypto::{
+    MerklePath,
+    keys::OutgoingViewingKey,
+    Node, PaymentAddress, ProofGenerationKey, Rseed
+};
+use redjubjub::{Signature, SpendAuth};
+use incrementalmerkletree::witness::IncrementalWitness;
 use crate::HashSeed;
 
 /**
@@ -200,7 +203,7 @@ where
  * @param deserializer - The deserializer instance.
  * @returns A result containing the deserialized `MerklePath<Node>` or an error.
  */
-pub fn merkle_path_deserialize<'de, D>(deserializer: D) -> Result<MerklePath<Node>, D::Error>
+pub fn merkle_path_deserialize<'de, D>(deserializer: D) -> Result<MerklePath, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -266,7 +269,7 @@ where
  * @param deserializer - The deserializer instance.
  * @returns A result containing the deserialized list of `Signature` or an error.
  */
-pub fn s_sig_deserialize<'de, D>(deserializer: D) -> Result<Vec<Signature>, D::Error>
+pub fn s_sig_deserialize<'de, D>(deserializer: D) -> Result<Vec<Signature<SpendAuth>>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/ledger-zcash-builder/src/lib.rs
+++ b/ledger-zcash-builder/src/lib.rs
@@ -36,13 +36,20 @@ use jubjub::AffinePoint;
 use rand::RngCore;
 use rand_core::OsRng;
 use txbuilder::SaplingMetadata;
+use redjubjub::Signature;
+use sapling_crypto::{
+    keys::OutgoingViewingKey,
+    MerklePath,
+    Node,
+    PaymentAddress,
+    ProofGenerationKey,
+    Rseed
+};
+use incrementalmerkletree::witness::IncrementalWitness;
 use zcash_primitives::{
     consensus::{self, Parameters, TestNetwork},
-    keys::OutgoingViewingKey,
     legacy::Script,
     memo::MemoBytes as Memo,
-    merkle_tree::{IncrementalWitness, MerklePath},
-    sapling::{redjubjub::Signature, Node, PaymentAddress, ProofGenerationKey, Rseed},
     transaction::{
         components::{Amount, OutPoint, TxOut},
         Transaction,

--- a/ledger-zcash-builder/src/prover.rs
+++ b/ledger-zcash-builder/src/prover.rs
@@ -139,7 +139,7 @@ impl SaplingProvingContext {
             rseed,
         };
 
-        let nullifier = note.nf(&viewing_key, merkle_path.position);
+        let nullifier = note.nf(&viewing_key.nk, merkle_path.position);
 
         // We now have the full witness for our circuit
         let instance = Spend {

--- a/ledger-zcash-builder/src/txbuilder.rs
+++ b/ledger-zcash-builder/src/txbuilder.rs
@@ -53,6 +53,7 @@ use crate::{
     txprover::HsmTxProver,
 };
 
+use ledger_zcash_legacy_helpers::script_to_address;
 mod builder_data;
 pub use builder_data::*;
 
@@ -316,7 +317,7 @@ impl<P: consensus::Parameters, R: RngCore + CryptoRng, SA: sapling::Authorizatio
         }
 
         
-        match address(&coin.script_pubkey) {
+        match script_to_address(&coin.script_pubkey) {
             Some(TransparentAddress::PublicKey(hash)) => {
                 use ripemd::{Digest as _, Ripemd160};
                 use sha2::{Digest as _, Sha256};
@@ -962,44 +963,6 @@ impl<P: consensus::Parameters, R: RngCore + CryptoRng>
     }
 }
 
-/// Minimal subset of script opcodes.
-enum OpCode {
-    // push value
-    PushData1 = 0x4c,
-    PushData2 = 0x4d,
-    PushData4 = 0x4e,
-
-    // stack ops
-    Dup = 0x76,
-
-    // bit logic
-    Equal = 0x87,
-    EqualVerify = 0x88,
-
-    // crypto
-    Hash160 = 0xa9,
-    CheckSig = 0xac,
-}
-
-fn address(script: &Script) -> Option<TransparentAddress> {
-    if script.0.len() == 25
-        && script.0[0..3] == [OpCode::Dup as u8, OpCode::Hash160 as u8, 0x14]
-        && script.0[23..25] == [OpCode::EqualVerify as u8, OpCode::CheckSig as u8]
-    {
-        let mut hash = [0; 20];
-        hash.copy_from_slice(&script.0[3..23]);
-        Some(TransparentAddress::PublicKey(hash))
-    } else if script.0.len() == 23
-        && script.0[0..2] == [OpCode::Hash160 as u8, 0x14]
-        && script.0[22] == OpCode::Equal as u8
-    {
-        let mut hash = [0; 20];
-        hash.copy_from_slice(&script.0[2..22]);
-        Some(TransparentAddress::Script(hash))
-    } else {
-        None
-    }
-}
 // #[cfg(test)]
 // mod tests {
 // use ff::{Field, PrimeField};

--- a/ledger-zcash-builder/src/txprover.rs
+++ b/ledger-zcash-builder/src/txprover.rs
@@ -20,8 +20,11 @@ use std::path::Path;
 use bellman::groth16::{Parameters, PreparedVerifyingKey, Proof};
 use bls12_381::Bls12;
 use ff::Field;
+use jubjub::Fq;
 use rand_core::OsRng;
-use redjubjub::{Binding, Signature, SpendAuth, VerificationKey};
+use redjubjub::{
+    Binding, Signature, SpendAuth, VerificationKey
+};
 use sapling_crypto::{
     bundle::GrothProofBytes, circuit::{Output, OutputParameters, Spend, SpendParameters}, prover::{OutputProver, SpendProver}, value::{NoteValue, ValueCommitTrapdoor}, Diversifier, MerklePath, PaymentAddress, ProofGenerationKey, Rseed
 };
@@ -290,7 +293,7 @@ impl SpendProver for LocalTxProver {
         value: NoteValue,
         alpha: jubjub::Fr,
         rcv: ValueCommitTrapdoor,
-        anchor: bls12_381::Scalar,
+        anchor: Fq,
         merkle_path: MerklePath,
     ) -> Option<Spend> {
         SpendParameters::prepare_circuit(

--- a/ledger-zcash-legacy-helpers/Cargo.toml
+++ b/ledger-zcash-legacy-helpers/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ledger-zcash-legacy-helpers"
+description = "Legacy helpers for zcash. This will be remove soon."
+version = "0.0.0"
+license = "Apache-2.0"
+authors = ["Zondax AG <hello@zondax.ch>"]
+homepage = "https://github.com/Zondax/ledger-zcash-rs"
+repository = "https://github.com/Zondax/ledger-zcash-rs"
+readme = "README.md"
+categories = ["authentication", "cryptography"]
+keywords = ["ledger", "nano", "apdu", "zcash"]
+edition = "2021"
+autobenches = false
+
+[lib]
+name = "ledger_zcash_legacy_helpers"
+
+[features]
+default = ["zcash_primitives"]
+
+[dependencies]
+zcash_primitives = { version = "0.8", features = ["transparent-inputs"], optional = true }
+

--- a/ledger-zcash-legacy-helpers/src/lib.rs
+++ b/ledger-zcash-legacy-helpers/src/lib.rs
@@ -1,0 +1,44 @@
+use zcash_primitives::legacy::{Script, TransparentAddress};
+
+///! Helpers to update to latest crates.
+/// this should eventually go away
+
+
+/// Minimal subset of script opcodes.
+enum OpCode {
+    // push value
+    // PushData1 = 0x4c,
+    // PushData2 = 0x4d,
+    // PushData4 = 0x4e,
+
+    // stack ops
+    Dup = 0x76,
+
+    // bit logic
+    Equal = 0x87,
+    EqualVerify = 0x88,
+
+    // crypto
+    Hash160 = 0xa9,
+    CheckSig = 0xac,
+}
+
+pub fn script_to_address(script: &Script) -> Option<TransparentAddress> {
+    if script.0.len() == 25
+        && script.0[0..3] == [OpCode::Dup as u8, OpCode::Hash160 as u8, 0x14]
+        && script.0[23..25] == [OpCode::EqualVerify as u8, OpCode::CheckSig as u8]
+    {
+        let mut hash = [0; 20];
+        hash.copy_from_slice(&script.0[3..23]);
+        Some(TransparentAddress::PublicKey(hash))
+    } else if script.0.len() == 23
+        && script.0[0..2] == [OpCode::Hash160 as u8, 0x14]
+        && script.0[22] == OpCode::Equal as u8
+    {
+        let mut hash = [0; 20];
+        hash.copy_from_slice(&script.0[2..22]);
+        Some(TransparentAddress::Script(hash))
+    } else {
+        None
+    }
+}

--- a/ledger-zcash/Cargo.toml
+++ b/ledger-zcash/Cargo.toml
@@ -41,11 +41,9 @@ secp256k1 = { version = "0.29", default-features = false }
 zx-bip44 = "0.1.0"
 ledger-transport = "0.11"
 ledger-zondax-generic = "0.11"
-ledger-zcash-builder = { version = "0.11.1" }
-
-zcash_primitives = { version = "0.7", features = [
-    "transparent-inputs",
-], optional = true }
+ledger-zcash-builder = { path = "../ledger-zcash-builder", version = "=0.11.2" }
+ledger-zcash-legacy-helpers = { path = "../ledger-zcash-legacy-helpers" }
+zcash_primitives = { version = "0.8", features = ["transparent-inputs"], optional = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/ledger-zcash/src/txbuilder.rs
+++ b/ledger-zcash/src/txbuilder.rs
@@ -35,7 +35,7 @@ use zcash_primitives::{
 use zx_bip44::BIP44Path;
 
 use crate::{DataInput, DataShieldedOutput, DataShieldedSpend, DataTransparentInput, DataTransparentOutput, ZcashApp};
-
+use ledger_zcash_legacy_helpers::script_to_address;
 /// Ergonomic ZCash transaction builder for HSM
 #[derive(Default)]
 pub struct Builder {
@@ -61,8 +61,8 @@ impl TryFrom<DataInput> for Builder {
 
         for to in input.vec_tout.into_iter() {
             builder.add_transparent_output(
-                &to.script_pubkey
-                    .address()
+                
+                    &script_to_address(&to.script_pubkey)
                     .ok_or(BuilderError::InvalidAddress)?,
                 to.value,
             )?;
@@ -187,7 +187,7 @@ impl Builder {
             ripemd.finalize()
         };
 
-        match coin.script_pubkey.address() {
+        match script_to_address(&coin.script_pubkey) {
             Some(TransparentAddress::PublicKey(hash)) if hash == pkh[..] => {},
             _ => return Err(BuilderError::InvalidUTXOAddress),
         }
@@ -520,7 +520,7 @@ impl Builder {
     where
         R: RngCore + CryptoRng,
         TX: HsmTxProver + Send + Sync,
-        P: Parameters + Send + Sync,
+        P: Parameters,
         E: ledger_transport::Exchange + Send + Sync,
         E::Error: std::error::Error,
     {


### PR DESCRIPTION
This is an ongoing effort to make `dev` branch use the latest `librustzcash` crates.


closes #37 

<!-- ClickUpRef: 8696u63tr -->
:link: [zboto Link](https://app.clickup.com/t/8696u63tr)